### PR TITLE
공격 쿨타임, 플레이어 HP 구현

### DIFF
--- a/소스/WorldEnd/Client/towerScene.h
+++ b/소스/WorldEnd/Client/towerScene.h
@@ -36,6 +36,7 @@ protected:
 
 	shared_ptr<Player>					m_player;
 	shared_ptr<Camera>					m_camera;
+	shared_ptr<TowerScene>					m_tscene;
 
 	// 다른 플레이어의 id 확인하기 위해서 추가
 	INT									                    m_left_other_player_id;

--- a/소스/WorldEnd/Server/Server.cpp
+++ b/소스/WorldEnd/Server/Server.cpp
@@ -46,6 +46,7 @@ int Server::Network()
 	for (auto& th : m_worker_threads)
 		th.join();
 
+	SendPlayerDataPacket();
 
 	closesocket(g_socket);
 	WSACleanup();
@@ -54,8 +55,6 @@ int Server::Network()
 
 void Server::WorkerThreads() 
 {
-
-	cout << "WorkerThread Start" << endl;
 	for (;;) {
 		DWORD num_bytes{};
 		LONG64 key{};
@@ -66,7 +65,7 @@ void Server::WorkerThreads()
 			if (exp_over->_comp_type == OP_ACCEPT) cout << "Accept Error";
 			else {
 				cout << "GQCS Error on client[" << key << "]\n";
-				Disconnect(static_cast<int>(key));
+				//Disconnect(static_cast<int>(key));
 				if (exp_over->_comp_type == OP_SEND) delete exp_over;
 				continue;
 			}
@@ -145,15 +144,15 @@ void Server::ProcessPacket(const int id, char* p)
 {
 	char packet_type = p[1];
 	Session& cl = clients[id];
-
+	
 	switch (packet_type)
 	{
 	case CS_PACKET_LOGIN:
 	{
 		CS_LOGIN_PACKET* login_packet = reinterpret_cast<CS_LOGIN_PACKET*>(p);
 		strcpy_s(cl.m_name, login_packet->name);
-		SendLoginOkPacket(cl);
 		cl.m_lock.lock();
+		SendLoginOkPacket(cl);
 		cl.m_state = STATE::ST_INGAME;
 		cl.m_lock.unlock();
 		cout << login_packet->name << " is connect" << endl;
@@ -172,10 +171,46 @@ void Server::ProcessPacket(const int id, char* p)
 
 		cout << "x: " << cl.m_player_data.pos .x << " y: " << cl.m_player_data.pos.y <<
 			" z: " << cl.m_player_data.pos.z << endl;
-		SendPlayerDataPacket();
+
 		break;
 	}
+	case CS_PACKET_PLAYER_ATTACK:
+	{
+	
+		CS_ATTACK_PACKET* attack_packet = reinterpret_cast<CS_ATTACK_PACKET*>(p);
 
+		SendPlayerAttackPacket(cl.m_player_data.id);
+			switch (attack_packet->key)
+			{
+			case INPUT_KEY_E:
+			{
+				cout << "공격!" << endl;
+				auto attack_start_time = std::chrono::system_clock::now();
+				while (1)
+				{
+					auto attack_end_time = std::chrono::system_clock::now();
+					auto sec = std::chrono::duration_cast<std::chrono::seconds>(attack_end_time - attack_start_time);
+					if (sec.count() > start_cool_time)
+					{
+						start_cool_time++;
+						remain_cool_time = end_cool_time - start_cool_time;
+						cout << "남은 공격 쿨타임: " << remain_cool_time << "초" << endl;
+					}
+					else if (start_cool_time == 5) {
+						start_cool_time = 0;
+						break;
+						
+					}
+				}
+
+				break;
+			}
+			
+		}
+
+		break;
+	}
+	
 	}
 }
 
@@ -200,7 +235,10 @@ void Server::SendLoginOkPacket(const Session& player) const
 	login_ok_packet.type = SC_PACKET_LOGIN_OK;
 	login_ok_packet.player_data.id = player.m_player_data.id;
 	login_ok_packet.player_data.active_check = true;
-	login_ok_packet.player_data.pos = DirectX::XMFLOAT3{ 0.0f, 0.0f, 0.0f };
+	login_ok_packet.player_data.pos.x = player.m_player_data.pos.x;
+	login_ok_packet.player_data.pos.y = player.m_player_data.pos.y;
+	login_ok_packet.player_data.pos.z = player.m_player_data.pos.z;
+	login_ok_packet.player_data.hp = player.m_player_data.hp;
 	strcpy_s(login_ok_packet.name, sizeof(login_ok_packet.name), player.m_name);
 
 	char buf[sizeof(login_ok_packet)];
@@ -212,8 +250,8 @@ void Server::SendLoginOkPacket(const Session& player) const
 	for (const auto& other : clients)
 	{
 		if (!other.m_player_data.active_check) continue;
-		const int retVal = WSASend(other.m_socket, &wsa_buf, 1, &sent_byte, 0, nullptr, nullptr);
-		if (retVal == SOCKET_ERROR) ErrorDisplay("Send(SC_LOGIN_OK_PACKET) Error");
+		const int retval = WSASend(other.m_socket, &wsa_buf, 1, &sent_byte, 0, nullptr, nullptr);
+		if (retval == SOCKET_ERROR) ErrorDisplay("Send(SC_LOGIN_OK_PACKET) Error");
 	}
 
 	// 새로 로그인한 클라이언트에게 현재 접속해 있는 모든 클라이언트들의 정보를 전송
@@ -227,15 +265,16 @@ void Server::SendLoginOkPacket(const Session& player) const
 		sub_packet.type = SC_PACKET_LOGIN_OK;
 		sub_packet.player_data = other.m_player_data;
 		strcpy_s(sub_packet.name, sizeof(sub_packet.name), other.m_name);
-		sub_packet.ready_check = other.m_ready_check;
+		//sub_packet.ready_check = other.m_ready_check;
 		sub_packet.player_type = other.m_player_type;
 
 		memcpy(buf, reinterpret_cast<char*>(&sub_packet), sizeof(sub_packet));
-		const int retVal = WSASend(player.m_socket, &wsa_buf, 1, &sent_byte, 0, nullptr, nullptr);
-		if (retVal == SOCKET_ERROR) ErrorDisplay("Recv(SC_LOGIN_OK_PACKET) Error");
+		const int retval = WSASend(player.m_socket, &wsa_buf, 1, &sent_byte, 0, nullptr, nullptr);
+		if (retval == SOCKET_ERROR) ErrorDisplay("Send(SC_LOGIN_OK_PACKET) Error");
 	}
 
-	std::cout << "[ id: " << static_cast<int>(player.m_player_data.id) << " Login Packet Received ]" << std::endl;
+	std::cout << "[ id: " << static_cast<int>(login_ok_packet.player_data.id) << " Login Packet Received ]" << std::endl;
+	cout << "HP: " << login_ok_packet.player_data.hp << endl;
 
 }
 
@@ -248,16 +287,25 @@ void Server::SendPlayerDataPacket()
 	for (int i = 0; i < MAX_USER; ++i)
 		update_packet.data[i] = clients[i].m_player_data;
 
+	for (int i = 1; i < MAX_USER; ++i) 
+	{
+		if (!update_packet.data[i].active_check)
+		{
+			update_packet.data[i].id = -1;
+		}
+	}
+
 	char buf[sizeof(update_packet)];
 	memcpy(buf, reinterpret_cast<char*>(&update_packet), sizeof(update_packet));
-	WSABUF wsabuf{ sizeof(buf), buf };
+	WSABUF wsa_buf{ sizeof(buf), buf };
 	DWORD sent_byte;
 
 	for (const auto& cl : clients)
 	{
-		if (!cl.m_player_data.active_check) continue;
-		const int retVal = WSASend(cl.m_socket, &wsabuf, 1, &sent_byte, 0, nullptr, nullptr);
-		if (retVal == SOCKET_ERROR)
+		if (!cl.m_player_data.active_check) continue; 
+		
+		const int retval = WSASend(cl.m_socket, &wsa_buf, 1, &sent_byte, 0, nullptr, nullptr);
+		if (retval == SOCKET_ERROR)
 		{
 			if (WSAGetLastError() == WSAECONNRESET)
 				std::cout << "[" << static_cast<int>(cl.m_player_data.id) << " Session] Disconnect" << std::endl;
@@ -266,6 +314,26 @@ void Server::SendPlayerDataPacket()
 	}
 	//cout << "작동중인 모든 클라이언트들에게 이동 결과를 알려줌" << endl;
 }
+
+void Server::SendPlayerAttackPacket(int pl_id)
+{
+	SC_ATTACK_PACKET attack_packet;
+	attack_packet.size = sizeof(attack_packet);
+	attack_packet.type = SC_PACKET_PLAYER_ATTACK;
+	attack_packet.id = pl_id;
+
+	char buf[sizeof(attack_packet)];
+	memcpy(buf, reinterpret_cast<char*>(&attack_packet), sizeof(attack_packet));
+	WSABUF wsa_buf{ sizeof(buf), buf };
+	DWORD sent_byte;
+
+	for (const auto& cl : clients) {
+		if (!cl.m_player_data.active_check) continue;
+		const int retval = WSASend(cl.m_socket, &wsa_buf, 1, &sent_byte, 0, nullptr, nullptr);
+		if (retval == SOCKET_ERROR) ErrorDisplay("Send(SC_ATTACK_PACKET) Error");
+	}
+}
+
 
 CHAR Server::GetNewId() const
 {
@@ -278,7 +346,6 @@ CHAR Server::GetNewId() const
 	std::cout << "Maximum Number of Clients" << std::endl;
 	return -1;
 }
-
 
 
 

--- a/소스/WorldEnd/Server/Server.h
+++ b/소스/WorldEnd/Server/Server.h
@@ -9,6 +9,11 @@ private:
 	vector <thread>                         m_worker_threads;
 
 	INT									    disconnect_cnt;	// 연결 끊긴 인원 수
+
+	int                                     start_cool_time  {};
+	int                                     end_cool_time = 5;
+	int                                     remain_cool_time{};
+
 public:
 	Server();
 	~Server() = default;
@@ -20,6 +25,7 @@ public:
 
 	void SendLoginOkPacket(const Session& player) const;
 	void SendPlayerDataPacket();
+	void SendPlayerAttackPacket(int pl_id);
 
 	CHAR GetNewId() const;
 };

--- a/소스/WorldEnd/Server/protocol.h
+++ b/소스/WorldEnd/Server/protocol.h
@@ -9,10 +9,14 @@ constexpr int MAX_USER = 3;
 
 constexpr char CS_PACKET_LOGIN = 1;
 constexpr char CS_PACKET_PLAYER_MOVE = 2;
+constexpr char CS_PACKET_PLAYER_ATTACK = 3;
 
 constexpr char SC_PACKET_LOGIN_OK = 1;
 constexpr char SC_PACKET_UPDATE_CLIENT = 2;
+constexpr char SC_PACKET_PLAYER_ATTACK = 3;
 
+
+constexpr char INPUT_KEY_E = 0b1000;
 
 enum class ePlayerType : char {SWORD, BOW};
 enum class eAttackType : char { NORMAL, SKILL };
@@ -26,6 +30,7 @@ struct PlayerData
 	DirectX::XMFLOAT3	pos;			// 위치
 	DirectX::XMFLOAT3	velocity;		// 속도
 	FLOAT				yaw;			// 회전각
+	INT                 hp;
 };
 
 struct ArrowData    
@@ -73,8 +78,9 @@ struct CS_ATTACK_PACKET
 {
 	UCHAR size;
 	UCHAR type;
-	ePlayerType player_type; // 근접 캐릭인지 원거리 캐릭인지 구별해주는 열거체 변수
-	eAttackType attack_type; // 기본 공격인이 스킬 공격인지 구별해주는 열거체 변수
+	//ePlayerType player_type; // 근접 캐릭인지 원거리 캐릭인지 구별해주는 열거체 변수
+	//eAttackType attack_type; // 기본 공격인이 스킬 공격인지 구별해주는 열거체 변수
+	CHAR key;
 };
 
 struct CS_ARROW_PACKET      // 공격키를 눌렀을때 투사체를 생성해주는 패킷
@@ -100,7 +106,7 @@ struct SC_LOGIN_OK_PACKET    // 로그인 성공을 알려주는 패킷
 	CHAR  name[NAME_SIZE];
 	PlayerData player_data;
 	ePlayerType player_type;
-	bool		ready_check;
+	//bool		ready_check;
 };
 
 struct SC_LOGIN_FAILL_PACKET  // 로그인 실패를 알려주는 패킷
@@ -146,6 +152,14 @@ struct SC_UPDATE_CLIENT_PACKET
 	UCHAR		type;
 	PlayerData	data[MAX_USER];
 };
+
+struct SC_ATTACK_PACKET
+{
+	UCHAR     size;
+	UCHAR     type;
+	CHAR      id;
+};
+
 #pragma pack (pop)
 
 

--- a/소스/WorldEnd/Server/session.cpp
+++ b/소스/WorldEnd/Server/session.cpp
@@ -1,7 +1,7 @@
 #include "session.h"
 #include "stdafx.h"
 
-Session::Session() : m_socket{}, m_player_data{ 0, false , {},{},{} }, m_ready_check{ FALSE }, 
+Session::Session() : m_socket{}, m_player_data{ 0, false , {},{},{} , 100}, m_ready_check{FALSE},
 m_player_type{ ePlayerType::SWORD }, m_state{ STATE::ST_FREE }, m_prev_size{ 0 }
 {
 	strcpy_s(m_name, "Player\0");


### PR DESCRIPTION
protocol.h에 있는 PlayerData라는 구조체에서 hp를 생성하여 서버에서 클라이언트로 보냈다.

클라이언트에서 E키를 입력 받을 시 공격을 수행하며 Server.cpp에 ProcessPacket 함수에서 쿨타임 계산 처리를 해주었음. 공격을 했다는 패킷을 다시 서버에서 클라로 id로 구별할 수 있게 보내줬다.

+ Server.cpp에 SendPlayerDataPacket 함수에서 들어오지 않은 플레이어들은 id를 -1값으로 바꾸어 클라이언트에서 들어온 플레이어들만 처리 할 수 있도록 수정하였다.